### PR TITLE
Check constant `CFCORE_VER` to see if Caldera Forms is active

### DIFF
--- a/src/third/calderaforms/class-caldera-active.php
+++ b/src/third/calderaforms/class-caldera-active.php
@@ -27,11 +27,7 @@ class Caldera_Active implements Third_Active_Interface_Weglot {
 			include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 		}
 
-		$active = true;
-
-		if ( ! is_plugin_active( 'caldera-forms/caldera-core.php' ) ) {
-			$active = false;
-		}
+		$active = defined( 'CFCORE_VER' );
 
 		return apply_filters( 'weglot_caldera_forms_is_active', $active );
 	}


### PR DESCRIPTION
We have a lot of customers who end up with different file paths for the plugin, and it causes problems with file path checks like `is_plugin_active()` does, so we've found checking this constant is more reliable.

https://calderaforms.com/doc/check-caldera-forms-active/