### PR TITLE
Fix use of escaping functions

### DIFF
--- a/src/widgets/class-widget-selector-weglot.php
+++ b/src/widgets/class-widget-selector-weglot.php
@@ -56,10 +56,10 @@ class Widget_Selector_Weglot extends \WP_Widget {
 			$title = '';
 		} ?>
 		<p>
-			<label for="<?php echo esc_html( $this->get_field_id( 'title' ) ); ?>">
+			<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>">
 				<?php esc_html_e( 'Title:', 'weglot' ); ?>
 			</label>
-			<input class="widefat" id="<?php echo esc_html( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_html( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>" />
+			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>" />
 		</p>
 		<?php
 	}
@@ -76,7 +76,7 @@ class Widget_Selector_Weglot extends \WP_Widget {
 	 */
 	public function update( $new_instance, $old_instance ) {
 		$instance            = [];
-		$instance['title']   = ( ! empty( $new_instance['title'] ) ) ? strip_tags( $new_instance['title'] ) : '';
+		$instance['title']   = ( ! empty( $new_instance['title'] ) ) ? sanitize_text_field( strip_tags( $new_instance['title'] ) ) : '';
 		return $instance;
 	}
 }

--- a/templates/admin/metaboxes/url-translate.php
+++ b/templates/admin/metaboxes/url-translate.php
@@ -44,11 +44,11 @@ else{
 			}
 		} ?>
 		<label for="lang-<?php echo esc_attr( $code ); ?>">
-			<strong><?php echo esc_attr( $language->getLocalName() ); ?></strong>
+			<strong><?php echo esc_html( $language->getLocalName() ); ?></strong>
 		</label>
 		<div class="weglot_custom_url">
 			<p class="weglot_custom_url--text_link">
-				<?php echo esc_url( home_url() ); ?>/<?php echo esc_attr( $code ); ?>/<?php echo esc_attr( $display_link ); ?><span id="text-edit-<?php echo esc_attr( $code ); ?>"><?php echo esc_attr( $post_name_weglot ); ?></span>
+				<?php echo esc_url( home_url() ); ?>/<?php echo esc_html( $code ); ?>/<?php echo esc_html( $display_link ); ?><span id="text-edit-<?php echo esc_attr( $code ); ?>"><?php echo esc_html( $post_name_weglot ); ?></span>
 				<input type="text" id="lang-<?php echo esc_attr( $code ); ?>" name="post_name_weglot[<?php echo esc_attr( $code ); ?>]" value="<?php echo esc_attr( $post_name_input ); ?>" style="display:none;"/>
 
 				<button type="button" class="button button-small button-weglot-lang" data-lang="<?php echo esc_attr( $code ); ?>" aria-label="Edit permalink weglot"><span class="dashicons dashicons-edit"></span> <?php esc_html_e( 'Edit', 'weglot' ); ?></button>
@@ -56,7 +56,7 @@ else{
 				<button type="button" class="button button-small button-weglot-lang-submit" data-lang="<?php echo esc_attr( $code ); ?>" style="display:none;"><?php esc_html_e( 'Ok', 'weglot' ); ?></button>
 			</p>
 			<p id="weglot_permalink_not_available_<?php echo esc_attr( $code ); ?>" class="weglot_text_error" style="display:none;"><?php esc_html_e( 'The permalink is not available.', 'weglot' ); ?></p>
-			<a id="weglot_reset_custom_<?php echo esc_attr( $code ); ?>" data-lang="<?php echo esc_attr( $code ); ?>" data-id="<?php echo esc_attr( $post->ID ); ?>" href="<?php echo $post_name_weglot ; ?>" class="weglot_reset">
+			<a id="weglot_reset_custom_<?php echo esc_attr( $code ); ?>" data-lang="<?php echo esc_attr( $code ); ?>" data-id="<?php echo esc_attr( $post->ID ); ?>" href="<?php echo esc_attr( $post_name_weglot ) ; ?>" class="weglot_reset">
 				<span class="dashicons dashicons-update-alt"></span> <?php esc_html_e( 'Reset custom url', 'weglot' ); ?>
 			</a>
 		</div>

--- a/templates/admin/pages/nav.php
+++ b/templates/admin/pages/nav.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			?>
 		<a
 			href="<?php echo esc_url( $tab['url'] ); ?>"
-			class="nav-tab <?php echo esc_html( $class_active ); ?>">
+			class="nav-tab <?php echo esc_attr( $class_active ); ?>">
 			<?php echo esc_html( $tab['title'] ); ?>
 		</a>
 			<?php

--- a/templates/admin/pages/settings.php
+++ b/templates/admin/pages/settings.php
@@ -76,7 +76,7 @@ $url_form = wp_nonce_url(
 			<h3><?php esc_html_e( 'Where are my translations?', 'weglot' ); ?></h3>
 			<div>
 				<p><?php esc_html_e( 'You can find all your translations in your Weglot account:', 'weglot' ); ?></p>
-				<a href="<?php esc_html_e( 'https://dashboard.weglot.com/translations/', 'weglot' ); ?>" target="_blank" class="weglot-editbtn">
+				<a href="<?php esc_attr_e( 'https://dashboard.weglot.com/translations/', 'weglot' ); ?>" target="_blank" class="weglot-editbtn">
 					<?php esc_html_e( 'Edit my translations', 'weglot' ); ?>
 				</a>
 			</div>

--- a/templates/admin/pages/tabs/advanced.php
+++ b/templates/admin/pages/tabs/advanced.php
@@ -97,7 +97,7 @@ $languages = array_values( $languages );
 										value="<?php echo esc_attr( $type ); ?>"
 										<?php echo selected( $type_option, $type ); ?>
 									>
-										<?php echo esc_attr( Helper_Excluded_Type::get_label_type( $type ) ); ?>
+										<?php echo esc_html( Helper_Excluded_Type::get_label_type( $type ) ); ?>
 									</option>
 								<?php endforeach; ?>
 							</select>

--- a/templates/admin/pages/tabs/custom-urls.php
+++ b/templates/admin/pages/tabs/custom-urls.php
@@ -34,7 +34,7 @@ if ( ! empty( $_GET['reset-all-custom-urls'] ) && 'true' === $_GET['reset-all-cu
 		foreach ( $options['custom_urls'] as $lang => $urls ) :
 			?>
 
-			<h3><?php esc_html_e( 'Lang : ', 'weglot' ); ?><?php echo $lang; ?></h3>
+			<h3><?php esc_html_e( 'Lang : ', 'weglot' ); ?><?php echo esc_html( $lang ); ?></h3>
 
 			<div style="display:flex;">
 				<div style="flex:5; margin-right:10px;">
@@ -51,13 +51,13 @@ if ( ! empty( $_GET['reset-all-custom-urls'] ) && 'true' === $_GET['reset-all-cu
 				?>
 				<div style="display:flex;" id="<?php echo $keyGenerate; ?>">
 					<div style="margin-right:10px; flex:5;">
-						<input style="max-width:100%;" type="text" value="<?php echo $value; ?>" class="base-url base-url-<?php echo $keyGenerate; ?>" data-key="<?php echo $keyGenerate; ?>" name="<?php echo sprintf( '%s[%s][%s][%s]', WEGLOT_SLUG, 'custom_urls', $lang, $key ); ?>" data-lang="<?php echo $lang; ?>" />
+						<input style="max-width:100%;" type="text" value="<?php echo esc_attr( $value ); ?>" class="base-url base-url-<?php echo esc_attr( $keyGenerate ); ?>" data-key="<?php echo esc_attr( $keyGenerate ); ?>" name="<?php echo esc_attr( sprintf( '%s[%s][%s][%s]', WEGLOT_SLUG, 'custom_urls', $lang, $key ) ); ?>" data-lang="<?php echo esc_attr( $lang ); ?>" />
 					</div>
 					<div style="flex:5;">
-						<input style="max-width:100%;"  type="text" value="<?php echo $key; ?>" data-key="<?php echo $keyGenerate; ?>" class="custom-url custom-<?php echo $keyGenerate; ?>" data-lang="<?php echo $lang; ?>" />
+						<input style="max-width:100%;"  type="text" value="<?php echo esc_attr( $key ); ?>" data-key="<?php echo esc_attr( $keyGenerate ); ?>" class="custom-url custom-<?php echo esc_attr( $keyGenerate ); ?>" data-lang="<?php echo esc_attr( $lang ); ?>" />
 					</div>
 					<div style="align-self:flex-end; flex:1; text-align: center; height: 32px;">
-						<button class="js-btn-remove" data-key="<?php echo $keyGenerate; ?>">
+						<button class="js-btn-remove" data-key="<?php echo esc_attr( $keyGenerate ); ?>">
 							<span class="dashicons dashicons-minus"></span>
 						</button>
 					</div>


### PR DESCRIPTION
There's quite a few places where the escaping functions are being used incorrectly. Specifically `esc_html` where `esc_attr` should be used for example. There was alsoa few other missing points of escaping that I've added.